### PR TITLE
fix suffix tree import fallback

### DIFF
--- a/generator/generation/substringmatch_generator.py
+++ b/generator/generation/substringmatch_generator.py
@@ -4,12 +4,7 @@ import hashlib
 import re
 import os
 
-try:
-    from generator.utils import UniSuffixTree
-
-    HAS_SUFFIX_TREE = True
-except Exception:
-    HAS_SUFFIX_TREE = False
+from generator.utils.unisuffixtree import UniSuffixTree, HAS_SUFFIX_TREE
 
 from .name_generator import NameGenerator
 from ..domains import Domains

--- a/generator/utils/__init__.py
+++ b/generator/utils/__init__.py
@@ -1,4 +1,3 @@
 from .aggregation import aggregate_duplicates
 from .itertools import sort_by_value
 from .unicode_wrap import unicode_wrap
-from .unisuffixtree import UniSuffixTree

--- a/generator/utils/suffixtree.py
+++ b/generator/utils/suffixtree.py
@@ -1,0 +1,10 @@
+try:
+    # import could fail if package not installed
+    from suffixtree import SuffixQueryTree
+    # building could fail if the arch is incompatible
+    SuffixQueryTree(False)
+    HAS_SUFFIX_TREE = True
+except Exception:
+    # make sure the name can be imported
+    SuffixQueryTree = None
+    HAS_SUFFIX_TREE = False

--- a/generator/utils/unisuffixtree.py
+++ b/generator/utils/unisuffixtree.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from suffixtree import SuffixQueryTree
+from generator.utils.suffixtree import SuffixQueryTree, HAS_SUFFIX_TREE
 from generator.utils import unicode_wrap
 
 

--- a/tests/test_name_generators.py
+++ b/tests/test_name_generators.py
@@ -29,7 +29,7 @@ import pytest
 
 from generator.domains import Domains
 
-from generator.generation.substringmatch_generator import HAS_SUFFIX_TREE
+from generator.utils.suffixtree import HAS_SUFFIX_TREE
 
 needs_suffix_tree = pytest.mark.skipif(not HAS_SUFFIX_TREE, reason='Suffix tree not available')
 

--- a/tests/test_suffix_tree.py
+++ b/tests/test_suffix_tree.py
@@ -1,11 +1,11 @@
 import pytest
-from generator.generation.substringmatch_generator import HAS_SUFFIX_TREE
+from generator.utils.unisuffixtree import HAS_SUFFIX_TREE
 
 if not HAS_SUFFIX_TREE:
     pytest.skip('Suffix tree not available', allow_module_level=True)
 
-from generator.utils import UniSuffixTree
-from suffixtree import SuffixQueryTree
+from generator.utils.unisuffixtree import UniSuffixTree
+from generator.utils.suffixtree import SuffixQueryTree
 
 
 def test_bug():


### PR DESCRIPTION
Własny build csuffixtree nie rzuca wyjątku przy imporcie na złej architekturze. Naprawiłem wykrywanie sytuacji kiedy suffix tree nie jest dostępny. Ułatwia życie programując na aarch64.