### PR TITLE
benchmark of random sampling

### DIFF
--- a/tests/manual_test_benchmark_sample.py
+++ b/tests/manual_test_benchmark_sample.py
@@ -1,0 +1,185 @@
+import random
+from itertools import accumulate
+
+import numpy as np
+
+from generator.generation.random_available_name_generator import _softmax
+
+random.seed(0)
+np.random.seed(0)
+
+n = 70  # 250000 70
+a = list(range(n))
+probabilities = [random.random() for _ in range(n)]
+probabilities[0] = 100
+probabilities = np.clip(probabilities, 0.0, 4.0)
+probabilities: list[float] = _softmax(probabilities).tolist()
+accumulated_probabilities = list(accumulate(probabilities))
+
+k = 200
+k = min(n, k)
+
+rng = np.random.default_rng()
+
+import heapq
+import math
+import random
+
+
+def WeightedSelectionWithoutReplacement():
+    elt = [(math.log(random.random()) / probabilities[i], i) for i in range(len(probabilities))]
+    return [x[1] for x in heapq.nlargest(k, elt)]
+
+
+def numpy_w_replace():
+    return np.random.choice(a, size=k, replace=True, p=probabilities)
+
+
+def numpy_wo_replace():
+    return np.random.choice(a, size=k, replace=False, p=probabilities)
+
+
+def random_w_replace_acc():
+    return random.choices(a, cum_weights=accumulated_probabilities, k=k)
+
+
+def random_w_replace():
+    return random.choices(a, weights=probabilities, k=k)
+
+
+def weighted_shuffle():
+    # http://utopia.duth.gr/~pefraimi/research/data/2007EncOfAlg.pdf ?
+    order = sorted(range(len(a)), key=lambda i: random.random() ** (1.0 / probabilities[i]))
+    return [a[i] for i in order[:k]]
+
+
+def weighted_shuffle_tree():
+    items = a
+    weights = probabilities
+    if len(items) != len(weights):
+        raise ValueError("Unequal lengths")
+
+    n = len(items)
+    nodes = [None for _ in range(n)]
+
+    def left_index(i):
+        return 2 * i + 1
+
+    def right_index(i):
+        return 2 * i + 2
+
+    def total_weight(i=0):
+        if i >= n:
+            return 0
+        this_weight = weights[i]
+        if this_weight <= 0:
+            raise ValueError("weight can't be zero or negative")
+        left_weight = total_weight(left_index(i))
+        right_weight = total_weight(right_index(i))
+        nodes[i] = [this_weight, left_weight, right_weight]
+        return this_weight + left_weight + right_weight
+
+    def sample(i=0):
+        this_w, left_w, right_w = nodes[i]
+        total = this_w + left_w + right_w
+        r = total * random.random()
+        if r < this_w:
+            nodes[i][0] = 0
+            return i
+        elif r < this_w + left_w:
+            chosen = sample(left_index(i))
+            nodes[i][1] -= weights[chosen]
+            return chosen
+        else:
+            chosen = sample(right_index(i))
+            nodes[i][2] -= weights[chosen]
+            return chosen
+
+    total_weight()  # build nodes tree
+
+    return (items[sample()] for _ in range(k))
+
+
+def rng_wo_replace_shuffle_false():
+    return rng.choice(a, k, replace=False, p=probabilities, shuffle=False)
+
+
+def rng_wo_replace_shuffle_true():
+    return rng.choice(a, k, replace=False, p=probabilities, shuffle=True)
+
+
+def rng_w_replace_shuffle_false():
+    return rng.choice(a, k, replace=True, p=probabilities, shuffle=False)
+
+
+def rng_w_replace_shuffle_true():
+    return rng.choice(a, k, replace=True, p=probabilities, shuffle=True)
+
+
+def fast_choice(options, probs):
+    x = random.random()
+    cum = 0
+    for i, p in enumerate(probs):
+        cum += p
+        if x < cum:
+            return options[i]
+    return options[-1]
+
+
+def check(r):
+    print(len(set(r)))
+
+
+def test_numpy_wo_replace(benchmark):
+    r = benchmark(numpy_wo_replace)
+    check(r)
+
+
+def test_numpy_w_replace(benchmark):
+    r = benchmark(numpy_w_replace)
+    check(r)
+
+
+def test_random_w_replace_acc(benchmark):
+    r = benchmark(random_w_replace_acc)
+    check(r)
+
+
+def test_random_w_replace(benchmark):
+    r = benchmark(random_w_replace)
+    check(r)
+
+
+def test_weighted_shuffle(benchmark):
+    r = benchmark(weighted_shuffle)
+    check(r)
+
+
+def test_weighted_shuffle_tree(benchmark):
+    r = benchmark(weighted_shuffle_tree)
+    check(r)
+
+
+def test_rng_wo_replace_shuffle_false(benchmark):
+    r = benchmark(rng_wo_replace_shuffle_false)
+    check(r)
+
+
+def test_rng_wo_replace_shuffle_true(benchmark):
+    r = benchmark(rng_wo_replace_shuffle_true)
+    check(r)
+
+
+def test_rng_w_replace_shuffle_false(benchmark):
+    r = benchmark(rng_w_replace_shuffle_false)
+    check(r)
+
+
+def test_rng_w_replace_shuffle_true(benchmark):
+    r = benchmark(rng_w_replace_shuffle_true)
+    check(r)
+
+
+def test_WeightedSelectionWithoutReplacement(benchmark):
+    r = benchmark(WeightedSelectionWithoutReplacement)
+    check(r)


### PR DESCRIPTION
For 70 elements:
```
------------------------------------------------------------------------------------------------- benchmark: 11 tests -------------------------------------------------------------------------------------------------
Name (time in us)                                 Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_random_w_replace_acc                     16.5730 (1.0)       96.4130 (1.0)       18.1479 (1.0)       4.1645 (1.0)       17.1480 (1.0)       0.7340 (1.0)       475;839       55.1027 (1.0)       12317           1
test_random_w_replace                         18.1690 (1.10)     121.1280 (1.26)      20.8964 (1.15)      7.0775 (1.70)      18.8190 (1.10)      1.0360 (1.41)     760;1137       47.8552 (0.87)      11097           1
test_weighted_shuffle                         21.8980 (1.32)     262.7170 (2.72)      24.2927 (1.34)      7.2768 (1.75)      23.2630 (1.36)      1.3093 (1.78)      358;417       41.1646 (0.75)       8917           1
test_WeightedSelectionWithoutReplacement      29.4870 (1.78)     143.0860 (1.48)      37.3950 (2.06)     12.5965 (3.02)      33.1810 (1.93)      4.1463 (5.65)      501;746       26.7415 (0.49)       4509           1
test_numpy_w_replace                          35.5920 (2.15)     207.4700 (2.15)      39.2611 (2.16)      8.4569 (2.03)      36.8440 (2.15)      2.1485 (2.93)      171;261       25.4705 (0.46)       2432           1
test_weighted_shuffle_tree                    37.9150 (2.29)     642.0659 (6.66)      50.7766 (2.80)     32.1816 (7.73)      38.9700 (2.27)      2.5900 (3.53)     979;1473       19.6941 (0.36)       8605           1
test_rng_w_replace_shuffle_true               38.8600 (2.34)     525.7960 (5.45)      62.7288 (3.46)     28.8346 (6.92)      54.3820 (3.17)     40.6162 (55.34)      176;19       15.9417 (0.29)       2305           1
test_rng_w_replace_shuffle_false              39.2290 (2.37)     148.9760 (1.55)      48.9983 (2.70)     15.8190 (3.80)      42.1820 (2.46)      5.5871 (7.61)      260;372       20.4089 (0.37)       1954           1
test_numpy_wo_replace                        140.1620 (8.46)     365.1600 (3.79)     176.9948 (9.75)     26.7193 (6.42)     165.7155 (9.66)     21.7680 (29.66)      182;67        5.6499 (0.10)       1054           1
test_rng_wo_replace_shuffle_false            141.7600 (8.55)     538.5510 (5.59)     187.7878 (10.35)    39.6896 (9.53)     176.4390 (10.29)    28.7123 (39.12)     221;114        5.3252 (0.10)       1367           1
test_rng_wo_replace_shuffle_true             145.8940 (8.80)     613.1900 (6.36)     226.4989 (12.48)    73.8700 (17.74)    199.0630 (11.61)    74.2057 (101.10)     166;64        4.4150 (0.08)        927           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
The best without replacement is `test_weighted_shuffle`.

For 200 out of 250000:
```
------------------------------------------------------------------------------------------------------------ benchmark: 11 tests ------------------------------------------------------------------------------------------------------------
Name (time in us)                                     Min                     Max                    Mean                 StdDev                  Median                    IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_random_w_replace_acc                        163.4510 (1.0)        1,952.8310 (1.0)          359.4264 (1.0)         250.9750 (1.0)          274.7980 (1.0)         231.0945 (1.0)         41;28  2,782.2104 (1.0)         444           1
test_random_w_replace                          6,601.4410 (40.39)     16,565.8090 (8.48)       9,194.3454 (25.58)     2,567.4373 (10.23)      8,379.0250 (30.49)     3,162.0830 (13.68)         5;2    108.7625 (0.04)         38           1
test_numpy_w_replace                          23,311.6850 (142.62)    53,057.0770 (27.17)     28,011.2944 (77.93)     7,102.4856 (28.30)     24,600.3285 (89.52)     5,165.7265 (22.35)         4;4     35.6999 (0.01)         28           1
test_numpy_wo_replace                         23,382.0800 (143.05)    41,434.3880 (21.22)     28,519.8530 (79.35)     5,457.4472 (21.74)     26,789.3670 (97.49)     8,231.8120 (35.62)         6;0     35.0633 (0.01)         32           1
test_rng_w_replace_shuffle_true               23,856.3500 (145.95)    30,078.6020 (15.40)     25,096.3270 (69.82)     1,193.7563 (4.76)      24,865.0480 (90.48)     1,036.6570 (4.49)          3;2     39.8465 (0.01)         30           1
test_rng_wo_replace_shuffle_false             24,066.5100 (147.24)    46,783.4160 (23.96)     28,364.2385 (78.92)     4,336.8140 (17.28)     27,890.6370 (101.50)    3,893.0982 (16.85)         3;1     35.2557 (0.01)         31           1
test_rng_w_replace_shuffle_false              24,983.9690 (152.85)    60,253.9550 (30.85)     35,343.7389 (98.33)    10,163.7280 (40.50)     30,513.3170 (111.04)   15,973.9230 (69.12)         4;0     28.2936 (0.01)         17           1
test_rng_wo_replace_shuffle_true              25,284.2290 (154.69)    45,551.5460 (23.33)     31,320.1688 (87.14)     7,140.9751 (28.45)     27,391.0260 (99.68)     8,882.0880 (38.43)         4;0     31.9283 (0.01)         25           1
test_weighted_shuffle                         75,136.5620 (459.69)   101,006.3350 (51.72)     86,645.0253 (241.06)    9,768.8926 (38.92)     86,889.9260 (316.20)   18,325.3340 (79.30)         3;0     11.5413 (0.00)         10           1
test_WeightedSelectionWithoutReplacement     102,901.1930 (629.55)   138,368.1630 (70.86)    113,081.6869 (314.62)   12,093.0444 (48.18)    107,370.0290 (390.72)   15,239.2012 (65.94)         2;0      8.8432 (0.00)          9           1
test_weighted_shuffle_tree                   398,855.0690 (>1000.0)  516,540.2220 (264.51)   451,584.3750 (>1000.0)  44,342.1418 (176.68)   451,211.1290 (>1000.0)  59,324.9605 (256.71)        2;0      2.2144 (0.00)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
The best without replacement is `test_numpy_wo_replace`.