### PR TITLE
CollectionGenerator reconfigured

### DIFF
--- a/conf/prod_config_new.yaml
+++ b/conf/prod_config_new.yaml
@@ -145,4 +145,4 @@ ngrams:
 collections:
   other_collections_path: data/collections_data/other_collections.json
   collections_limit: 3
-  suggestions_limit: 20  # per one collections
+  suggestions_limit: 10  # per one collections

--- a/conf/test_config_new.yaml
+++ b/conf/test_config_new.yaml
@@ -148,4 +148,4 @@ ngrams:
 collections:
   other_collections_path: data/collections_data/other_collections.json
   collections_limit: 3
-  suggestions_limit: 20  # per one collections
+  suggestions_limit: 10  # per one collections


### PR DESCRIPTION
Has literally no effect, since we have been taking from the `top10..` field and slicing `[:20]`, so it has been working alright from the start. This is merely for self-documentation purposes